### PR TITLE
restructured integration tests

### DIFF
--- a/gradle.d/30-java.gradle
+++ b/gradle.d/30-java.gradle
@@ -1,3 +1,7 @@
+project.ext {
+    MongoIntegrationTests = 'com.github.reflectoring.infiniboard.test.categories.MongoIntegrationTests'
+}
+
 subprojects {
 
     if (file('src/main/java').exists()) {
@@ -6,6 +10,12 @@ subprojects {
 
         repositories {
             jcenter()
+        }
+
+        dependencies {
+            testCompile (
+                    project(':test-base'),
+            )
         }
 
         jacoco {
@@ -20,7 +30,10 @@ subprojects {
         }
 
         test {
-            useJUnit()
+            useJUnit {
+                // exclude all categories as default
+                excludeCategories project.MongoIntegrationTests
+            }
 
             // set heap size for the test JVM(s)
             minHeapSize = "128m"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,16 @@
 # java
 version_java=1.8
 
+# spring boot
 version_springBoot=1.3.2.RELEASE
 version_springLoaded=1.2.4.RELEASE
 
+# jacoco
 version_jacoco=0.7.1.201405082137
-
 
 # javascript
 version_node=5.5.0
 version_npm=3.5.3
 
+# mongo_plugin
+version_mongo_plugin=0.11.0

--- a/harvester/build.gradle
+++ b/harvester/build.gradle
@@ -1,38 +1,29 @@
 buildscript {
-
     dependencies {
         classpath "org.springframework.boot:spring-boot-gradle-plugin:${version_springBoot}"
-        classpath 'com.sourcemuse.gradle.plugin:gradle-mongo-plugin:0.11.0'
+        classpath "com.sourcemuse.gradle.plugin:gradle-mongo-plugin:${version_mongo_plugin}"
     }
-
 }
 
 apply plugin: 'spring-boot'
 apply plugin: 'mongo'
 
 dependencies {
-    compile(
+    compile (
             'org.springframework.boot:spring-boot-starter',
             'org.springframework.boot:spring-boot-starter-web',
             'org.springframework.boot:spring-boot-starter-actuator',
             'org.springframework.boot:spring-boot-starter-data-mongodb'
     )
 
-    testCompile(
-            project(':test-base'),
+    testCompile (
             'org.springframework.boot:spring-boot-starter-test'
     )
 }
 
-test {
-    useJUnit {
-        excludeCategories 'com.github.reflectoring.infiniboard.test.categories.MongoIntegrationTests'
-    }
-}
-
 task integrationTest(type: Test) {
-    runWithMongoDb = true
+    runWithMongoDb = true // activates mongo plugin to start embedded MongoDB
     useJUnit {
-        includeCategories 'com.github.reflectoring.infiniboard.test.categories.MongoIntegrationTests'
+        includeCategories project.MongoIntegrationTests
     }
 }

--- a/quartermaster/build.gradle
+++ b/quartermaster/build.gradle
@@ -1,25 +1,30 @@
-apply plugin: 'spring-boot'
-
 buildscript {
-
     dependencies {
         classpath "org.springframework.boot:spring-boot-gradle-plugin:${version_springBoot}"
         classpath "org.springframework:springloaded:${version_springLoaded}"
+        classpath "com.sourcemuse.gradle.plugin:gradle-mongo-plugin:${version_mongo_plugin}"
     }
 }
 
+apply plugin: 'spring-boot'
+apply plugin: 'mongo'
+
 dependencies {
-    compile 'org.springframework.boot:spring-boot-starter-web'
+    compile (
+            'org.springframework.boot:spring-boot-starter-web',
+            'org.springframework.boot:spring-boot-starter-data-mongodb'
+    )
 
-    compile('org.springframework.boot:spring-boot-starter-data-mongodb')
+    testCompile (
+            'org.springframework.boot:spring-boot-starter-test',
+    )
+}
 
-    // disable embedded mongo
-    // ./gradlew -Pno_embedded_mongo ...
-    if (!project.hasProperty('no_embedded_mongo')) {
-        compile('de.flapdoodle.embed:de.flapdoodle.embed.mongo:1.50.2')
+task integrationTest(type: Test) {
+    runWithMongoDb = true // activates mongo plugin to start embedded MongoDB
+    useJUnit {
+        includeCategories project.MongoIntegrationTests
     }
-
-    testCompile 'org.springframework.boot:spring-boot-starter-test'
 }
 
 bootRun {

--- a/quartermaster/build.gradle
+++ b/quartermaster/build.gradle
@@ -3,6 +3,7 @@ buildscript {
         classpath "org.springframework.boot:spring-boot-gradle-plugin:${version_springBoot}"
         classpath "org.springframework:springloaded:${version_springLoaded}"
         classpath "se.transmode.gradle:gradle-docker:${version_gradleDocker}"
+        classpath "com.sourcemuse.gradle.plugin:gradle-mongo-plugin:${version_mongo_plugin}"
     }
 }
 

--- a/quartermaster/build.gradle
+++ b/quartermaster/build.gradle
@@ -35,6 +35,7 @@ task integrationTest(type: Test) {
     useJUnit {
         includeCategories project.MongoIntegrationTests
     }
+}
 
 bootRepackage {
     mainClass = 'com.github.reflectoring.InfiniboardApplication'

--- a/quartermaster/src/test/java/com/github/reflectoring/InfiniboardApplicationTests.java
+++ b/quartermaster/src/test/java/com/github/reflectoring/InfiniboardApplicationTests.java
@@ -1,6 +1,8 @@
 package com.github.reflectoring;
 
+import com.github.reflectoring.infiniboard.test.categories.MongoIntegrationTests;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.boot.test.SpringApplicationConfiguration;
@@ -9,6 +11,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = InfiniboardApplication.class)
 @WebAppConfiguration
+@Category(MongoIntegrationTests.class)
 public class InfiniboardApplicationTests {
 
 	@Test


### PR DESCRIPTION
- easier use of category in projects
 - every java project depends on test-base for testing
 - using project property for category class name
 - excluding category at standard test task
- mongo plugin uses version property
- quartermaster also uses integration test and mongo plugin

