### PR TITLE
removed deprecated gulp-minify-css, using gulp-clean-css now

### DIFF
--- a/infiniboard-app/gulpfile.js
+++ b/infiniboard-app/gulpfile.js
@@ -6,7 +6,7 @@ var gulp = require('gulp'),
   del = require('del'),
   usemin = require('gulp-usemin'),
   uglify = require('gulp-uglify'),
-  minifyCss = require('gulp-minify-css'),
+  cleanCss = require('gulp-clean-css'),
   replace = require('gulp-replace'),
   gulpTypings = require("gulp-typings"),
   tslint = require('gulp-tslint');
@@ -80,7 +80,7 @@ gulp.task('app_html', function () {
   return gulp.src('index.html')
     .pipe(usemin({
       assetsDir: '',
-      css: [minifyCss()
+      css: [cleanCss()
         .pipe(replace('fonts', 'lib/font-awesome/fonts')), 'concat'],
       js: [uglify(), 'concat']
     }))

--- a/infiniboard-app/package.json
+++ b/infiniboard-app/package.json
@@ -29,7 +29,7 @@
     "concurrently": "^1.0.0",
     "del": "^2.2.0",
     "gulp": "^3.9.0",
-    "gulp-minify-css": "^1.2.3",
+    "gulp-clean-css": "^2.0.3",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",
     "gulp-traceur": "^0.17.2",


### PR DESCRIPTION
switched from `gulp-minify-css` to `gulp-clean-css` as `gulp-minify-css` is deprecated: https://www.npmjs.com/package/gulp-minify-css