### PR TITLE
quartermaster does not build infiniboard client by default now

### DIFF
--- a/quartermaster/build.gradle
+++ b/quartermaster/build.gradle
@@ -66,10 +66,11 @@ clean.dependsOn cleanWebappDir
 // clean old webapp first
 copyClient.dependsOn cleanWebappDir
 
-// wenn copyClient und npmInstall ausgeführt werden muss npmInstall zuerst ausgeführt werden
+// Der client kann erst kopiert werden, nachdem er gebaut wurde
 copyClient.mustRunAfter ':infiniboard-app:npmInstall'
-// wenn build und copyClient ausgeführt werden muss copyClient zuerst ausgeführt werden
-build.mustRunAfter copyClient
+
+// der client muss kopiert werden, bevor die quartermaster WAR gebaut wird
+processResources.mustRunAfter copyClient
 
 task buildWithClient {
     dependsOn ':infiniboard-app:npmInstall', copyClient, build

--- a/quartermaster/build.gradle
+++ b/quartermaster/build.gradle
@@ -17,7 +17,7 @@ configurations {
 }
 
 dependencies {
-    compile (
+    compile(
             'org.springframework.boot:spring-boot-starter-web',
             'org.springframework.boot:spring-boot-starter-data-mongodb'
     )
@@ -26,7 +26,7 @@ dependencies {
             "org.springframework.boot:spring-boot-starter-tomcat"
     )
 
-    testCompile (
+    testCompile(
             'org.springframework.boot:spring-boot-starter-test',
     )
 }
@@ -55,14 +55,10 @@ task cleanWebappDir(type: Delete) {
     delete 'src/main/webapp'
 }
 
-
 task copyClient(type: Copy) {
     from '../infiniboard-app/build'
     into 'src/main/webapp'
 }
-
-// infiniboard-app must be build first
-processResources.dependsOn ":infiniboard-app:npmInstall"
 
 // clean should also clean webapp dir
 clean.dependsOn cleanWebappDir
@@ -70,10 +66,16 @@ clean.dependsOn cleanWebappDir
 // clean old webapp first
 copyClient.dependsOn cleanWebappDir
 
-// processResources copies the client to webapp dir
-processResources.dependsOn copyClient
+// wenn copyClient und npmInstall ausgeführt werden muss npmInstall zuerst ausgeführt werden
+copyClient.mustRunAfter ':infiniboard-app:npmInstall'
+// wenn build und copyClient ausgeführt werden muss copyClient zuerst ausgeführt werden
+build.mustRunAfter copyClient
 
-task buildDocker(type: Docker, dependsOn: build) {
+task buildWithClient {
+    dependsOn ':infiniboard-app:npmInstall', copyClient, build
+}
+
+task buildDocker(type: Docker, dependsOn: buildWithClient) {
 //  push = true
     tagVersion = project.version
     tag = "${project.dockerGroup}/${war.baseName}"


### PR DESCRIPTION
* `:quartermaster:build` does no longer build `infiniboard-app`
* `:quartermaster:buildWithClient` builds `infiniboard-app` and packages it into `quartermaster`
* `:quartermaster:buildDocker` builds `infiniboard-app`,packages it into `quartermaster` and builds a docker image based on the war file

* CI build must be run with both tasks `./gradlew build buildWithClient`