### PR TITLE
moved to circle.ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://snap-ci.com/reflectoring/infiniboard/branch/master/build_image)](https://snap-ci.com/reflectoring/infiniboard/branch/master) [![Gradle Status](https://gradleupdate.appspot.com/reflectoring/infiniboard/status.svg?branch=master)](https://gradleupdate.appspot.com/reflectoring/infiniboard/status)
+[![Build Status](https://snap-ci.com/reflectoring/infiniboard/branch/master/build_image)](https://snap-ci.com/reflectoring/infiniboard/branch/master) [![Build Status](https://circleci.com/gh/matthiasbalke/infiniboard/tree/circleci.svg?style=shield&circle-token=75e95e854013500044492bdd5a7990aecbc97a92)](https://circleci.com/gh/matthiasbalke/infiniboard) [![Gradle Status](https://gradleupdate.appspot.com/reflectoring/infiniboard/status.svg?branch=master)](https://gradleupdate.appspot.com/reflectoring/infiniboard/status)
 
 # infiniboard
 infiniboard is a customizable, general purpose project dashboard to assist you in gathering your most important project metrics in one place.

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,53 @@
+machine:
+  java:
+    version: oraclejdk8
+  node:
+    version: 4.4.0
+
+  services:
+    - docker
+    - mongodb
+
+dependencies:
+  cache_directories:
+    - "~/docker"
+    - "~/.npm"
+  override:
+    - docker info
+    - if [[ -e ~/docker/mongo.tar ]]; then docker load --input ~/docker/mongo.tar; fi
+    - if [[ -e ~/docker/quartermaster.tar ]]; then docker load --input ~/docker/quartermaster.tar; fi
+    - if [[ -e ~/docker/harvester.tar ]]; then docker load --input ~/docker/harvester.tar; fi
+
+    - ./gradlew --console=plain buildDocker -Pno_embedded_mongo
+
+    # pull image here to cache it and speed up the test
+    - docker pull mongo:3.2
+    - docker images
+
+    - mkdir -p ~/docker
+    - docker save mongo > ~/docker/mongo.tar
+    - docker save matthiasbalke/quartermaster > ~/docker/quartermaster.tar
+    - docker save matthiasbalke/harvester > ~/docker/harvester.tar
+
+  post:
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+    - find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+
+    - mkdir -p $CIRCLE_ARTIFACTS/build-artifacts
+    - cp -a harvester/build/libs/harvester*.jar $CIRCLE_ARTIFACTS/build-artifacts/
+    - cp -a quartermaster/build/libs/quartermaster*.war $CIRCLE_ARTIFACTS/build-artifacts/
+
+test:
+  override:
+    - docker run -d              mongo:3.2;
+    - docker run -d -p 8080:8080 matthiasbalke/quartermaster --link mongo:mongo;
+    - docker run -d              matthiasbalke/harvester     --link mongo:mongo; sleep 30
+    - curl --retry 10 --retry-delay 5 -v http://localhost:8080
+
+deployment:
+  hub:
+    branch: circleci
+    commands:
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+      - docker push matthiasbalke/quartermaster
+      - docker push matthiasbalke/harvester

--- a/circle.yml
+++ b/circle.yml
@@ -15,8 +15,7 @@ dependencies:
   override:
     - docker info
     - if [[ -e ~/docker/mongo.tar ]]; then docker load --input ~/docker/mongo.tar; fi
-    - if [[ -e ~/docker/quartermaster.tar ]]; then docker load --input ~/docker/quartermaster.tar; fi
-    - if [[ -e ~/docker/harvester.tar ]]; then docker load --input ~/docker/harvester.tar; fi
+    - if [[ -e ~/docker/java.tar ]]; then docker load --input ~/docker/java.tar; fi
 
     - ./gradlew --console=plain buildDocker -Pno_embedded_mongo
 
@@ -26,8 +25,7 @@ dependencies:
 
     - mkdir -p ~/docker
     - docker save mongo > ~/docker/mongo.tar
-    - docker save matthiasbalke/quartermaster > ~/docker/quartermaster.tar
-    - docker save matthiasbalke/harvester > ~/docker/harvester.tar
+    - docker save java:8 > ~/docker/java.tar
 
   post:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/

--- a/gradle.d/15-circleci.gradle
+++ b/gradle.d/15-circleci.gradle
@@ -31,10 +31,10 @@ ext {
 // reads environment variables when running on snap-ci.com
     isCiBuild = getBoolEnv('CI', false)
 
-    buildNumber = getEnv('SNAP_PIPELINE_COUNTER', null)
-    gitCommit = getEnv('SNAP_COMMIT', null)
-    gitCommitShort = getEnv('SNAP_COMMIT_SHORT', null)
-    pullRequestNumber = getEnv('SNAP_PULL_REQUEST_NUMBER', null)
+    buildNumber = getEnv('CIRCLE_BUILD_NUM', null)
+    gitCommit = getEnv('CIRCLE_SHA1', null)
+    gitCommitShort = getEnv('CIRCLE_SHA1', null)
+    pullRequestNumber = getEnv('CIRCLE_PR_NUMBER', null)
     isPullRequest = pullRequestNumber != null
 
     // export method as closure to make it available for all projects
@@ -49,4 +49,3 @@ println "gitCommitShort   : ${gitCommitShort}"
 println "isPullRequest    : ${isPullRequest}"
 println "pullRequestNumber: ${pullRequestNumber}"
 println ""
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # project
-dockerGroup=reflectoring
+dockerGroup=matthiasbalke
 
 # java
 version_java=1.8

--- a/harvester/build.gradle
+++ b/harvester/build.gradle
@@ -37,8 +37,8 @@ task integrationTest(type: Test) {
 }
 
 task buildDocker(type: Docker, dependsOn: build) {
-//  push = true
-    tagVersion = project.version
+    push = false
+    tagVersion = 'latest'
     tag = "${project.dockerGroup}/${jar.baseName}"
 
     dockerfile = file('src/main/docker/Dockerfile')

--- a/quartermaster/build.gradle
+++ b/quartermaster/build.gradle
@@ -77,8 +77,8 @@ task buildWithClient {
 }
 
 task buildDocker(type: Docker, dependsOn: buildWithClient) {
-//  push = true
-    tagVersion = project.version
+    push = false
+    tagVersion = 'latest'
     tag = "${project.dockerGroup}/${war.baseName}"
 
     dockerfile = file('src/main/docker/Dockerfile')


### PR DESCRIPTION
As snap-ci.com does not support building docker images, this PR configures a circle.ci build which builds docker images and pushes them to the docker hub.

Somes changes have to be made before it can be merged:

- [ ]  change URL in `README.md` badge
- [ ]  change docker group in `gradle.properties`
- [ ]  change docker group in `circle.yml`
- [x]  push `quartermaster` as version `latest` if its not a final release
- [x]  push `harvester` as version `latest` if its not a final release