### PR TITLE
fixed widget creation example

### DIFF
--- a/createWidget.txt
+++ b/createWidget.txt
@@ -3,7 +3,7 @@
   "sourceConfigs" : [
     {
       "id" : "urlSource",
-      "type" : "UrlSource",
+      "type" : "urlSource",
       "interval" : 1000,
       "configData" :
         {


### PR DESCRIPTION
The widget creation example was not altered after switching to lower case job types. This PR fixes the creation of the widget.