### PR TITLE
add html test reports to build artifacts (closes #57)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -37,6 +37,8 @@ dependencies:
   post:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
     - find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit-html/
+    - find . -type d -regex ".**/build/reports/tests" -exec sh -c 'cp -a {} $CIRCLE_TEST_REPORTS/junit-html/`echo {} | cut -d / -f2`' \;
 
     - mkdir -p $CIRCLE_ARTIFACTS/build-artifacts
     - cp -a harvester/build/libs/harvester*.jar $CIRCLE_ARTIFACTS/build-artifacts/


### PR DESCRIPTION
copies gradle junit html reports to circleci artifacts for easier browsing