### PR TITLE
Automatic deploy to github pages

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,7 @@ dependencies:
     - cd dashy && ng test
     - cd dashy && ng build --prod
 
-    - ./gradlew --stacktrace --console=plain build integrationTest
+    - ./gradlew --stacktrace --console=plain build integrationTest asciidoctor
     - if [ "$CIRCLE_PR_NUMBER" = ""  ]; then ./gradlew --stacktrace --console=plain sonarqube; else ./gradlew --stacktrace --console=plain sonarqube -Dsonar.analysis.mode=issues -Dsonar.github.pullRequest=$CIRCLE_PR_NUMBER -Dsonar.github.repository=$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME -Dsonar.github.oauth=$SONAR_GITHUB_OAUTH; fi
     - ./gradlew --stacktrace --console=plain buildDocker
 

--- a/circle.yml
+++ b/circle.yml
@@ -80,6 +80,11 @@ test:
     - docker logs infiniboard_quartermaster_1 > $CIRCLE_TEST_REPORTS/docker/quartermaster.log
 
 deployment:
+  ghPages:
+    branch: master
+    commands:
+      - if [ "$CIRCLE_PR_NUMBER" = ""  ]; then cd quartermaster && ../gradlew publishGhPages; else echo 'Skipping GitHub pages deployment for PRs!'; fi
+
   hub:
     branch: master
     commands:

--- a/quartermaster/build.gradle
+++ b/quartermaster/build.gradle
@@ -113,8 +113,6 @@ asciidoctor {
     outputDir 'build/doc/restapi'
 }
 
-build.dependsOn asciidoctor
-
 githubPages {
     repoUri = 'git@github.com:reflectoring/infiniboard.git'
     targetBranch = 'gh-pages'

--- a/quartermaster/build.gradle
+++ b/quartermaster/build.gradle
@@ -113,6 +113,8 @@ asciidoctor {
     outputDir 'build/doc/restapi'
 }
 
+build.dependsOn asciidoctor
+
 githubPages {
     repoUri = 'git@github.com:reflectoring/infiniboard.git'
     targetBranch = 'gh-pages'

--- a/quartermaster/build.gradle
+++ b/quartermaster/build.gradle
@@ -118,7 +118,7 @@ githubPages {
     targetBranch = 'gh-pages'
     pages {
         from 'build/doc/restapi/html5'
-        into "${version}/docs/restapi"
+        into "${baseVersion}/docs/restapi"
     }
 }
 

--- a/quartermaster/build.gradle
+++ b/quartermaster/build.gradle
@@ -114,10 +114,12 @@ asciidoctor {
 }
 
 githubPages {
-    repoUri = 'https://github.com/reflectoring/infiniboard.git'
+    repoUri = 'git@github.com:reflectoring/infiniboard.git'
     targetBranch = 'gh-pages'
     pages {
         from 'build/doc/restapi/html5'
         into "${version}/docs/restapi"
     }
 }
+
+publishGhPages.dependsOn asciidoctor


### PR DESCRIPTION
Add automatic REST documentation deployment to GitHub pages via SSH (fixes #104).

Maybe an SSH key must be configured on circleci if deployment key is not enough.