### PR TITLE
Removed Gradle deprecation warnings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ version_spotless=3.0.0
 #
 #
 # spring boot
-version_springBoot=1.5.1.RELEASE
+version_springBoot=1.5.2.RELEASE
 version_springLoaded=1.2.6.RELEASE
 #
 #


### PR DESCRIPTION
The deprecation warnings where caused by the spring boot plugin. In 1.5.2 they fixed the gradle API usage.

**Changes**
* updated spring boot (fixes #171)